### PR TITLE
Add group chat experience and refresh UI/UX

### DIFF
--- a/DBConfiguration/GroupChat.sql
+++ b/DBConfiguration/GroupChat.sql
@@ -1,0 +1,36 @@
+-- グループ機能用テーブル
+CREATE TABLE `GroupRooms` (
+  `groupID` int NOT NULL AUTO_INCREMENT,
+  `groupName` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+  `description` text COLLATE utf8mb4_general_ci,
+  `ownerID` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+  `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`groupID`),
+  KEY `ownerID` (`ownerID`),
+  CONSTRAINT `GroupRooms_ibfk_1` FOREIGN KEY (`ownerID`) REFERENCES `Users` (`userID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `GroupMembers` (
+  `groupID` int NOT NULL,
+  `userID` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+  `role` varchar(50) COLLATE utf8mb4_general_ci NOT NULL DEFAULT 'member',
+  `joinedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`groupID`,`userID`),
+  KEY `userID` (`userID`),
+  CONSTRAINT `GroupMembers_ibfk_1` FOREIGN KEY (`groupID`) REFERENCES `GroupRooms` (`groupID`) ON DELETE CASCADE,
+  CONSTRAINT `GroupMembers_ibfk_2` FOREIGN KEY (`userID`) REFERENCES `Users` (`userID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `GroupMessages` (
+  `messageID` int NOT NULL AUTO_INCREMENT,
+  `groupID` int NOT NULL,
+  `userID` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+  `commentText` text COLLATE utf8mb4_general_ci,
+  `appendFile` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `createdAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`messageID`),
+  KEY `groupID` (`groupID`),
+  KEY `userID` (`userID`),
+  CONSTRAINT `GroupMessages_ibfk_1` FOREIGN KEY (`groupID`) REFERENCES `GroupRooms` (`groupID`) ON DELETE CASCADE,
+  CONSTRAINT `GroupMessages_ibfk_2` FOREIGN KEY (`userID`) REFERENCES `Users` (`userID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/GroupChat/GroupHistory.php
+++ b/GroupChat/GroupHistory.php
@@ -1,0 +1,52 @@
+<?php
+require '../src/db-connect.php';
+
+$pdo = new PDO($connect, user, pass);
+$groupID = $_GET['groupID'] ?? null;
+$viewerID = $_GET['userID'] ?? '';
+
+if (!$groupID) {
+    exit();
+}
+
+$sql = 'SELECT gm.messageID, gm.userID, gm.commentText, gm.appendFile, gm.createdAt, u.nickname, u.profileIcon
+        FROM GroupMessages gm
+        JOIN Users u ON gm.userID = u.userID
+        WHERE gm.groupID = ?
+        ORDER BY gm.createdAt ASC, gm.messageID ASC';
+$history = $pdo->prepare($sql);
+$history->execute([$groupID]);
+
+if ($history->rowCount() >= 1):
+    foreach ($history as $row):
+        $isMine = ($row['userID'] === $viewerID);
+?>
+        <div class="message <?= $isMine ? 'mine' : 'other' ?>">
+            <div class="user">
+                <div class="avatar">
+                    <?php if (!empty($row['profileIcon'])) { ?>
+                        <img src="<?= htmlspecialchars($row['profileIcon']) ?>" alt="profileIcon">
+                    <?php } else { ?>
+                        <img src="../image/DefaultIcon.svg" alt="profileIcon">
+                    <?php } ?>
+                </div>
+                <div class="user-meta">
+                    <p class="nickname"><?= htmlspecialchars($row['nickname']) ?></p>
+                    <span class="timestamp"><?= htmlspecialchars($row['createdAt']) ?></span>
+                </div>
+            </div>
+            <p class="body"><?= nl2br(htmlspecialchars($row['commentText'], ENT_QUOTES, 'UTF-8')) ?></p>
+            <?php if (!empty($row['appendFile'])): ?>
+                <div class="appendimg">
+                    <img src="<?= htmlspecialchars($row['appendFile'], ENT_QUOTES, 'UTF-8') ?>" alt="添付ファイル">
+                </div>
+            <?php endif; ?>
+        </div>
+<?php
+    endforeach;
+else:
+?>
+    <p class="empty">まだメッセージがありません。最初のメッセージを投稿しましょう。</p>
+<?php
+endif;
+?>

--- a/GroupChat/GroupList.php
+++ b/GroupChat/GroupList.php
@@ -1,0 +1,185 @@
+<?php
+session_start();
+require '../src/db-connect.php';
+$pdo = new PDO($connect, user, pass);
+
+$currentUser = $_SESSION['users'] ?? null;
+$userID = $currentUser['id'] ?? null;
+$statusMessage = '';
+
+function h($string) {
+    return htmlspecialchars($string, ENT_QUOTES, 'UTF-8');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!$userID) {
+        header('Location: ../Login/LoginIn.php');
+        exit();
+    }
+
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'create') {
+        $groupName = trim($_POST['groupName'] ?? '');
+        $description = trim($_POST['description'] ?? '');
+
+        if ($groupName === '') {
+            $statusMessage = 'グループ名を入力してください。';
+        } else {
+            $createGroup = $pdo->prepare('INSERT INTO GroupRooms (groupName, description, ownerID) VALUES (?, ?, ?)');
+            $createGroup->execute([$groupName, $description, $userID]);
+            $groupID = $pdo->lastInsertId();
+
+            $insertOwner = $pdo->prepare('INSERT INTO GroupMembers (groupID, userID, role) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE role = VALUES(role)');
+            $insertOwner->execute([$groupID, $userID, 'owner']);
+            $statusMessage = 'グループを作成しました。';
+        }
+    } elseif ($action === 'join') {
+        $groupID = $_POST['groupID'] ?? '';
+        if ($groupID !== '') {
+            $join = $pdo->prepare('INSERT INTO GroupMembers (groupID, userID, role) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE role = VALUES(role)');
+            $join->execute([$groupID, $userID, 'member']);
+            $statusMessage = 'グループに参加しました。';
+        }
+    } elseif ($action === 'leave') {
+        $groupID = $_POST['groupID'] ?? '';
+        if ($groupID !== '') {
+            $leave = $pdo->prepare('DELETE FROM GroupMembers WHERE groupID = ? AND userID = ?');
+            $leave->execute([$groupID, $userID]);
+            $statusMessage = 'グループから退出しました。';
+        }
+    }
+}
+
+$groupSql = 'SELECT g.groupID, g.groupName, g.description, g.ownerID, g.createdAt, u.nickname AS ownerName, COUNT(m.userID) AS memberCount
+             FROM GroupRooms g
+             LEFT JOIN GroupMembers m ON g.groupID = m.groupID
+             LEFT JOIN Users u ON g.ownerID = u.userID
+             GROUP BY g.groupID
+             ORDER BY g.createdAt DESC';
+$groups = $pdo->query($groupSql)->fetchAll(PDO::FETCH_ASSOC);
+
+$memberships = [];
+if ($userID) {
+    $membershipStmt = $pdo->prepare('SELECT groupID, role FROM GroupMembers WHERE userID = ?');
+    $membershipStmt->execute([$userID]);
+    foreach ($membershipStmt as $memberRow) {
+        $memberships[$memberRow['groupID']] = $memberRow['role'];
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="./css/group-list.css">
+    <link rel="icon" href="../image/SiteIcon.svg" type="image/svg">
+    <title>グループ一覧 | Yadi-X</title>
+</head>
+<body>
+    <?php require '../Header/Header.php'; ?>
+    <div class="group-page">
+        <section class="hero">
+            <div>
+                <p class="eyebrow">Group</p>
+                <h1>グループを見つけよう</h1>
+                <p class="lead">興味のあるトピックやクラスメイトとつながれるグループを作成・参加できます。</p>
+            </div>
+            <?php if ($statusMessage) { ?>
+                <div class="status"><?= h($statusMessage) ?></div>
+            <?php } ?>
+        </section>
+
+        <section class="grid">
+            <div class="panel">
+                <div class="panel-header">
+                    <div>
+                        <p class="eyebrow">Create</p>
+                        <h2>新しいグループを作成</h2>
+                    </div>
+                </div>
+                <?php if ($userID) { ?>
+                    <form class="create-form" method="post">
+                        <input type="hidden" name="action" value="create">
+                        <label class="field">
+                            <span>グループ名</span>
+                            <input type="text" name="groupName" placeholder="例：チーム開発メンバー" required>
+                        </label>
+                        <label class="field">
+                            <span>紹介文</span>
+                            <textarea name="description" rows="3" placeholder="活動内容や目的を共有しましょう"></textarea>
+                        </label>
+                        <button type="submit" class="primary-btn">グループを作成</button>
+                    </form>
+                <?php } else { ?>
+                    <div class="cta">
+                        <p>グループ作成にはログインが必要です。</p>
+                        <a class="primary-btn" href="../Login/LoginIn.php">ログインする</a>
+                    </div>
+                <?php } ?>
+            </div>
+
+            <div class="panel groups">
+                <div class="panel-header">
+                    <div>
+                        <p class="eyebrow">Join</p>
+                        <h2>参加可能なグループ</h2>
+                    </div>
+                    <span class="count-chip">全<?= count($groups) ?>件</span>
+                </div>
+                <div class="group-cards">
+                    <?php if (empty($groups)) { ?>
+                        <p class="empty">まだグループがありません。最初のグループを作成しましょう。</p>
+                    <?php }
+                    foreach ($groups as $group) {
+                        $groupId = $group['groupID'];
+                        $isMember = array_key_exists($groupId, $memberships);
+                        $ownerName = $group['ownerName'] ?? '不明';
+                        $createdAt = $group['createdAt'] ?? null;
+                        $createdText = $createdAt ? date('Y/m/d', strtotime($createdAt)) : '日付未設定';
+                        ?>
+                        <div class="group-card">
+                            <div class="card-header">
+                                <div>
+                                    <p class="sub">作成者: <?= h($ownerName) ?></p>
+                                    <h3><?= h($group['groupName']) ?></h3>
+                                </div>
+                                <?php if ($isMember) { ?>
+                                    <span class="badge">参加中</span>
+                                <?php } ?>
+                            </div>
+                            <p class="description"><?= nl2br(h($group['description'] ?: 'まだ紹介文がありません。')) ?></p>
+                            <div class="meta">
+                                <span><?= $group['memberCount'] ?>人が参加</span>
+                                <span>作成日: <?= $createdText ?></span>
+                            </div>
+                            <div class="actions">
+                                <?php if ($userID) { ?>
+                                    <?php if ($isMember) { ?>
+                                        <form method="post">
+                                            <input type="hidden" name="groupID" value="<?= h($groupId) ?>">
+                                            <input type="hidden" name="action" value="leave">
+                                            <button type="submit" class="secondary-btn">退出する</button>
+                                        </form>
+                                        <a href="./GroupRoom.php?groupID=<?= h($groupId) ?>" class="primary-btn ghost">チャットを開く</a>
+                                    <?php } else { ?>
+                                        <form method="post">
+                                            <input type="hidden" name="groupID" value="<?= h($groupId) ?>">
+                                            <input type="hidden" name="action" value="join">
+                                            <button type="submit" class="primary-btn">参加する</button>
+                                        </form>
+                                        <button class="secondary-btn" disabled>チャットを開く</button>
+                                    <?php } ?>
+                                <?php } else { ?>
+                                    <a class="primary-btn" href="../Login/LoginIn.php">ログインして参加</a>
+                                <?php } ?>
+                            </div>
+                        </div>
+                    <?php } ?>
+                </div>
+            </div>
+        </section>
+    </div>
+</body>
+</html>

--- a/GroupChat/GroupRoom.php
+++ b/GroupChat/GroupRoom.php
@@ -1,0 +1,145 @@
+<?php
+session_start();
+require '../src/db-connect.php';
+$pdo = new PDO($connect, user, pass);
+
+if (!isset($_SESSION['users'])) {
+    header('Location: ../Login/LoginIn.php');
+    exit();
+}
+
+$userID = $_SESSION['users']['id'];
+$groupID = $_GET['groupID'] ?? null;
+
+if (!$groupID) {
+    header('Location: ./GroupList.php');
+    exit();
+}
+
+$groupStmt = $pdo->prepare('SELECT g.groupID, g.groupName, g.description, g.ownerID, u.nickname AS ownerName FROM GroupRooms g LEFT JOIN Users u ON g.ownerID = u.userID WHERE g.groupID = ?');
+$groupStmt->execute([$groupID]);
+$group = $groupStmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$group) {
+    header('Location: ./GroupList.php');
+    exit();
+}
+
+$membershipStmt = $pdo->prepare('SELECT role FROM GroupMembers WHERE groupID = ? AND userID = ?');
+$membershipStmt->execute([$groupID, $userID]);
+$membership = $membershipStmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$membership) {
+    header('Location: ./GroupList.php');
+    exit();
+}
+
+$membersStmt = $pdo->prepare('SELECT gm.userID, gm.role, u.nickname, u.profileIcon FROM GroupMembers gm JOIN Users u ON gm.userID = u.userID WHERE gm.groupID = ? ORDER BY gm.role DESC, u.nickname');
+$membersStmt->execute([$groupID]);
+$members = $membersStmt->fetchAll(PDO::FETCH_ASSOC);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $chat = trim($_POST['chat'] ?? '');
+    $uploadedFile = $_FILES['file'] ?? null;
+    $filePath = null;
+
+    if ($uploadedFile && $uploadedFile['error'] === UPLOAD_ERR_OK) {
+        $uploadDir = __DIR__ . '/uploads/';
+        if (!file_exists($uploadDir)) {
+            mkdir($uploadDir, 0755, true);
+        }
+        $fileType = strtolower(pathinfo($uploadedFile['name'], PATHINFO_EXTENSION));
+        $fileName = substr(sha1(basename($uploadedFile['tmp_name']) . rand(0, 9)), 0, 15) . '.' . $fileType;
+        $uploadFilePath = $uploadDir . $fileName;
+        if (move_uploaded_file($uploadedFile['tmp_name'], $uploadFilePath)) {
+            $filePath = './uploads/' . $fileName;
+        }
+    }
+
+    if ($chat !== '' || $filePath !== null) {
+        $insert = $pdo->prepare('INSERT INTO GroupMessages (groupID, userID, commentText, appendFile) VALUES (?, ?, ?, ?)');
+        $insert->execute([$groupID, $userID, $chat, $filePath]);
+        header('Location: ./GroupRoom.php?groupID=' . urlencode($groupID));
+        exit();
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="./css/group-room.css">
+    <link rel="icon" href="../image/SiteIcon.svg" type="image/svg">
+    <title><?= htmlspecialchars($group['groupName']) ?> | グループチャット</title>
+    <script>
+        const groupID = <?= json_encode($groupID) ?>;
+        const currentUserId = <?= json_encode($userID) ?>;
+    </script>
+</head>
+<body>
+    <?php require '../Header/Header.php'; ?>
+    <div class="room">
+        <aside class="members">
+            <div class="members-header">
+                <div>
+                    <p class="eyebrow">Members</p>
+                    <h3>参加メンバー</h3>
+                </div>
+                <span class="count-chip"><?= count($members) ?>人</span>
+            </div>
+            <div class="member-list">
+                <?php foreach ($members as $member) { ?>
+                    <div class="member">
+                        <div class="avatar">
+                            <?php if (!empty($member['profileIcon'])) { ?>
+                                <img src="<?= htmlspecialchars($member['profileIcon']) ?>" alt="icon">
+                            <?php } else { ?>
+                                <img src="../image/DefaultIcon.svg" alt="icon">
+                            <?php } ?>
+                        </div>
+                        <div class="info">
+                            <p class="name"><?= htmlspecialchars($member['nickname']) ?></p>
+                            <span class="role <?= $member['role'] === 'owner' ? 'owner' : '' ?>"><?= htmlspecialchars($member['role']) ?></span>
+                        </div>
+                    </div>
+                <?php } ?>
+            </div>
+            <a class="secondary-btn" href="./GroupList.php">グループ一覧へ戻る</a>
+        </aside>
+
+        <main class="chat-area">
+            <div class="chat-header">
+                <div>
+                    <p class="eyebrow">Group Chat</p>
+                    <h2><?= htmlspecialchars($group['groupName']) ?></h2>
+                    <p class="sub">作成者: <?= htmlspecialchars($group['ownerName'] ?? '不明') ?></p>
+                </div>
+                <div class="pill">メッセージは自動更新されます</div>
+            </div>
+            <div class="chat-history" id="groupHistory"></div>
+
+            <form class="chat-form" method="post" enctype="multipart/form-data">
+                <div id="file-preview-container">
+                    <img id="file-preview" />
+                    <span id="file-name"></span>
+                    <img src="../image/Dustbin.svg" id="delete-button" onclick="removeFile()" alt="削除">
+                </div>
+                <div class="input-row">
+                    <textarea name="chat" class="text" placeholder="メッセージを入力" rows="2" spellcheck="false"></textarea>
+                    <div class="form-actions">
+                        <button type="button" class="icon-btn" onclick="triggerFileInput(event)">
+                            <img src="../image/FileIcon.svg" alt="ファイルを添付">
+                        </button>
+                        <input type="file" id="file-input" name="file" style="display: none;" onchange="displayFileName(this)">
+                        <button type="submit" class="icon-btn">
+                            <img src="../image/SendIcon.svg" alt="送信">
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </main>
+    </div>
+    <script src="./js/group-chat.js"></script>
+</body>
+</html>

--- a/GroupChat/css/group-list.css
+++ b/GroupChat/css/group-list.css
@@ -1,0 +1,223 @@
+body {
+    background-color: #2c2c2c;
+    color: #fff;
+    font-family: 'Noto Sans JP', 'Segoe UI', sans-serif;
+    margin: 0;
+}
+
+h1, h2, h3 {
+    margin: 4px 0;
+}
+
+.group-page {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px 18px 40px;
+    box-sizing: border-box;
+}
+
+.hero {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    margin-bottom: 12px;
+}
+
+.lead {
+    color: #d5d5d5;
+    line-height: 1.6;
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 12px;
+    color: #9ef0c2;
+    margin: 0 0 6px 0;
+}
+
+.status {
+    background: rgba(6, 194, 134, 0.16);
+    border: 1px solid #06c286;
+    color: #b9ffe3;
+    padding: 12px 14px;
+    border-radius: 12px;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: 1fr 1.6fr;
+    gap: 14px;
+}
+
+.panel {
+    background: #3b3b3b;
+    border: 1px solid #4d4d4d;
+    border-radius: 16px;
+    padding: 16px;
+    box-shadow: 0 8px 22px rgba(0, 0, 0, 0.4);
+}
+
+.panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.count-chip {
+    background: rgba(255, 255, 255, 0.08);
+    padding: 8px 12px;
+    border-radius: 999px;
+    font-weight: bold;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 10px;
+    color: #d7d7d7;
+}
+
+.field input,
+.field textarea {
+    border-radius: 10px;
+    border: 1px solid #06c286;
+    padding: 10px 12px;
+    background: #2b2b2b;
+    color: #fff;
+    outline: none;
+}
+
+.field textarea {
+    resize: vertical;
+}
+
+.primary-btn,
+.secondary-btn {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    border-radius: 12px;
+    padding: 10px 14px;
+    border: none;
+    cursor: pointer;
+    font-weight: bold;
+    color: #fff;
+    text-decoration: none;
+    transition: transform 0.08s ease, box-shadow 0.12s ease, opacity 0.12s ease;
+}
+
+.primary-btn {
+    background: linear-gradient(90deg, #06c286 0%, #0aa36d 100%);
+    box-shadow: 0 8px 20px rgba(6, 194, 134, 0.35);
+    border: 1px solid #06c286;
+}
+
+.primary-btn.ghost {
+    background: transparent;
+    color: #06c286;
+    border: 1px solid #06c286;
+    box-shadow: none;
+}
+
+.secondary-btn {
+    background: #454545;
+    border: 1px solid #5a5a5a;
+    color: #e7e7e7;
+}
+
+.primary-btn:disabled,
+.secondary-btn:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.primary-btn:hover,
+.secondary-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.28);
+}
+
+.create-form {
+    display: flex;
+    flex-direction: column;
+}
+
+.cta {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.groups .group-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 12px;
+}
+
+.group-card {
+    background: #2f2f2f;
+    border: 1px solid #454545;
+    border-radius: 14px;
+    padding: 14px;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.sub {
+    color: #c9c9c9;
+    margin: 0 0 4px 0;
+}
+
+.badge {
+    background: rgba(6, 194, 134, 0.2);
+    color: #06c286;
+    border: 1px solid #06c286;
+    padding: 6px 10px;
+    border-radius: 999px;
+    font-weight: bold;
+}
+
+.description {
+    color: #e8e8e8;
+    line-height: 1.5;
+    min-height: 60px;
+}
+
+.meta {
+    display: flex;
+    justify-content: space-between;
+    color: #d0d0d0;
+    font-size: 14px;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.empty {
+    color: #d0d0d0;
+    margin: 10px 0;
+}
+
+@media (max-width: 1000px) {
+    .grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/GroupChat/css/group-room.css
+++ b/GroupChat/css/group-room.css
@@ -1,0 +1,308 @@
+body {
+    background: #2c2c2c;
+    color: #fff;
+    font-family: 'Noto Sans JP', 'Segoe UI', sans-serif;
+    margin: 0;
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 12px;
+    color: #9ef0c2;
+    margin: 0 0 4px 0;
+}
+
+.sub {
+    margin: 4px 0 0 0;
+    color: #d5d5d5;
+}
+
+.room {
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: 12px;
+    height: calc(100vh - 70px);
+    padding: 12px 14px 18px;
+    box-sizing: border-box;
+}
+
+.members {
+    background: #3b3b3b;
+    border: 1px solid #4d4d4d;
+    border-radius: 16px;
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.38);
+    overflow: hidden;
+}
+
+.members-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.member-list {
+    overflow-y: auto;
+    padding-right: 4px;
+    flex: 1;
+}
+
+.member {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    padding: 8px 6px;
+    border-radius: 10px;
+    transition: background 0.1s ease;
+}
+
+.member:hover {
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    overflow: hidden;
+    border: 2px solid #06c286;
+    flex-shrink: 0;
+}
+
+.avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.info .name {
+    margin: 0;
+    font-weight: bold;
+}
+
+.role {
+    display: inline-block;
+    padding: 3px 8px;
+    border-radius: 999px;
+    background: #4b4b4b;
+    font-size: 12px;
+    margin-top: 4px;
+    text-transform: capitalize;
+}
+
+.role.owner {
+    background: rgba(6, 194, 134, 0.2);
+    color: #06c286;
+    border: 1px solid #06c286;
+}
+
+.count-chip {
+    background: rgba(255, 255, 255, 0.08);
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-weight: bold;
+}
+
+.secondary-btn {
+    background: #454545;
+    border: 1px solid #5a5a5a;
+    color: #fff;
+    padding: 10px 12px;
+    text-decoration: none;
+    text-align: center;
+    border-radius: 12px;
+    font-weight: bold;
+}
+
+.chat-area {
+    background: #363636;
+    border-radius: 16px;
+    border: 1px solid #4a4a4a;
+    box-shadow: 0 10px 26px rgba(0, 0, 0, 0.42);
+    display: flex;
+    flex-direction: column;
+    padding: 12px 12px 16px;
+    box-sizing: border-box;
+}
+
+.chat-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.pill {
+    border: 1px solid #06c286;
+    color: #06c286;
+    border-radius: 999px;
+    padding: 8px 12px;
+    background: rgba(6, 194, 134, 0.12);
+}
+
+.chat-history {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px 6px;
+    border-radius: 12px;
+    background: rgba(0, 0, 0, 0.12);
+}
+
+.message {
+    padding: 10px 12px;
+    margin-bottom: 10px;
+    border-radius: 12px;
+    background: #2f2f2f;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.28);
+}
+
+.message.mine {
+    background: linear-gradient(90deg, rgba(6, 194, 134, 0.3) 0%, rgba(6, 194, 134, 0.16) 100%);
+    border: 1px solid rgba(6, 194, 134, 0.5);
+}
+
+.message .user {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    margin-bottom: 6px;
+}
+
+.message .avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+}
+
+.user-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.nickname {
+    margin: 0;
+    font-weight: bold;
+}
+
+.timestamp {
+    color: #d0d0d0;
+    font-size: 12px;
+}
+
+.body {
+    margin: 6px 0;
+    line-height: 1.6;
+}
+
+.appendimg img {
+    max-width: 100%;
+    max-height: 240px;
+    border-radius: 10px;
+    object-fit: cover;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
+}
+
+.chat-form {
+    margin-top: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+#file-preview-container {
+    display: none;
+    align-items: center;
+    border: 1px dashed #06c286;
+    padding: 10px 12px;
+    border-radius: 12px;
+    background: rgba(6, 194, 134, 0.08);
+    position: relative;
+    gap: 10px;
+}
+
+#file-preview {
+    display: none;
+    max-height: 160px;
+    border-radius: 8px;
+}
+
+#delete-button {
+    width: 26px;
+    height: 26px;
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    cursor: pointer;
+    display: none;
+}
+
+.input-row {
+    display: flex;
+    gap: 10px;
+    align-items: flex-end;
+}
+
+.text {
+    flex: 1;
+    border-radius: 14px;
+    border: 2px solid #06c286;
+    background: #2b2b2b;
+    color: #fff;
+    padding: 10px 12px;
+    min-height: 60px;
+    resize: vertical;
+    outline: none;
+}
+
+.form-actions {
+    display: flex;
+    gap: 6px;
+}
+
+.icon-btn {
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    border: 1px solid #06c286;
+    background: #2b2b2b;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+.icon-btn img {
+    width: 22px;
+    height: 22px;
+}
+
+.empty {
+    color: #d0d0d0;
+    margin: 10px 0;
+}
+
+@media (max-width: 900px) {
+    .room {
+        grid-template-columns: 1fr;
+        height: auto;
+    }
+
+    .members {
+        flex-direction: row;
+        flex-wrap: wrap;
+        height: auto;
+    }
+
+    .member-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        max-height: none;
+        overflow: visible;
+    }
+}

--- a/GroupChat/js/group-chat.js
+++ b/GroupChat/js/group-chat.js
@@ -1,0 +1,70 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const chatHistory = document.getElementById('groupHistory');
+    let isFirstLoad = true;
+
+    async function fetchHistory() {
+        try {
+            const response = await fetch(`./GroupHistory.php?groupID=${encodeURIComponent(groupID)}&userID=${encodeURIComponent(currentUserId)}`);
+            if (!response.ok) return;
+            const html = await response.text();
+            chatHistory.innerHTML = html;
+            if (isFirstLoad) {
+                chatHistory.scrollTop = chatHistory.scrollHeight;
+                isFirstLoad = false;
+            }
+        } catch (error) {
+            console.error('Failed to fetch history', error);
+        }
+    }
+
+    fetchHistory();
+    setInterval(fetchHistory, 8000);
+});
+
+function triggerFileInput(event) {
+    event.preventDefault();
+    document.getElementById('file-input').click();
+}
+
+function displayFileName(input) {
+    const file = input.files[0];
+    const filePreviewContainer = document.getElementById('file-preview-container');
+    const filePreview = document.getElementById('file-preview');
+    const fileName = document.getElementById('file-name');
+    const deleteButton = document.getElementById('delete-button');
+
+    if (file) {
+        filePreviewContainer.style.display = 'flex';
+        fileName.textContent = file.name;
+        deleteButton.style.display = 'block';
+
+        if (file.type.startsWith('image/')) {
+            const reader = new FileReader();
+            reader.onload = function(e) {
+                filePreview.src = e.target.result;
+                filePreview.style.display = 'block';
+            };
+            reader.readAsDataURL(file);
+        } else {
+            filePreview.style.display = 'none';
+            filePreview.src = '';
+        }
+    } else {
+        removeFile();
+    }
+}
+
+function removeFile() {
+    const fileInput = document.getElementById('file-input');
+    const filePreviewContainer = document.getElementById('file-preview-container');
+    const filePreview = document.getElementById('file-preview');
+    const fileName = document.getElementById('file-name');
+    const deleteButton = document.getElementById('delete-button');
+
+    fileInput.value = '';
+    filePreviewContainer.style.display = 'none';
+    filePreview.style.display = 'none';
+    filePreview.src = '';
+    fileName.textContent = '';
+    deleteButton.style.display = 'none';
+}

--- a/Top/TopPage.php
+++ b/Top/TopPage.php
@@ -17,15 +17,15 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                 die('Failed to create directory.');
             }
         }
-        $file = './File/' . substr(sha1(basename($_FILES['file']['tmp_name']) . rand(0, 9)), 0, 15) . '.' .strtolower(pathinfo($_FILES['file']['name'], PATHINFO_EXTENSION));
+        $file = './File/' . substr(sha1(basename($_FILES['file']['tmp_name']) . rand(0, 9)), 0, 15) . '.' . strtolower(pathinfo($_FILES['file']['name'], PATHINFO_EXTENSION));
         if (move_uploaded_file($_FILES['file']['tmp_name'], $file)) {
         }
-    }else{
-        $file=null;
+    } else {
+        $file = null;
     }
     if (!empty($commentText) || $file !== null) {
         $sql = $pdo->prepare('INSERT INTO GlobalChat (userID, commentText, appendFile) VALUES (?, ?, ?)');
-        $sql->execute([$userid,$commentText,$file]);
+        $sql->execute([$userid, $commentText, $file]);
         header('Location: ' . $_SERVER['PHP_SELF']);
         exit();
     }
@@ -48,8 +48,8 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         <div class="content">
             <div class="sideber">
                 <?php
-                $chatsql=$pdo->prepare("SELECT DISTINCT CASE WHEN dm.userID = :userID THEN dm.partnerID ELSE dm.userID END AS friendID, u.nickname, u.profileIcon 
-                        FROM DirectMessage dm JOIN Users u ON (CASE WHEN dm.userID = :userID THEN dm.partnerID ELSE dm.userID END) = u.userID 
+                $chatsql = $pdo->prepare("SELECT DISTINCT CASE WHEN dm.userID = :userID THEN dm.partnerID ELSE dm.userID END AS friendID, u.nickname, u.profileIcon
+                        FROM DirectMessage dm JOIN Users u ON (CASE WHEN dm.userID = :userID THEN dm.partnerID ELSE dm.userID END) = u.userID
                         WHERE dm.userID = :userID OR dm.partnerID = :userID");
                 $chatsql->execute(['userID' => $userID]);
                 $directchat = $chatsql->fetchAll(PDO::FETCH_ASSOC);
@@ -78,14 +78,14 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                             <div class="menu-icon">
                                 <a href="../Question/ListForum.php">
                                     <img src="../image/Q&A.svg" alt="Q&A" class="icon-img">
-                                </a href="../Question/ListForum.php">
+                                </a>
                             </div>
                             <a href="../Question/ListForum.php"><span class="menu-text">Q&A</span></a>
                         </label>
                     </li>
                     <li>
                         <label><?php
-                            if(isset($_SESSION['users'])){?>
+                            if (isset($_SESSION['users'])) { ?>
                                 <div class="menu-icon">
                                     <img src="../image/Chat.svg" alt="Chat" class="icon-img">
                                 </div>
@@ -93,45 +93,64 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                                     <span class="menu-text">Chat</span>
                                     <div class="list">
                                         <?php
-                                        foreach($directchat as $chat){ ?>
+                                        foreach ($directchat as $chat) { ?>
                                             <p class="listname"><a href="../PersonalChat/PersonalChat.php?partnerID=<?= $chat['friendID'] ?>"> <?= $chat['nickname'] ?></a></p>
                                         <?php } ?>
                                     </div>
                                 </div><?php
-                            } else {?>
+                            } else { ?>
                                 <div class="menu-icon">
                                     <a href="../Login/LoginIn.php">
                                         <img src="../image/Chat.svg" alt="Chat" class="icon-img">
                                     </a>
                                 </div>
                                 <a href="../Login/LoginIn.php"><span class="menu-text">Chat</span></a><?php
-                            }?>
+                            } ?>
                         </label>
                     </li>
                     <li>
-                        <label>
+                        <label><?php if (isset($_SESSION['users'])) { ?>
                                 <div class="menu-icon">
-                                    <a href="../GroupChat/Unimplemented.php">
+                                    <a href="../GroupChat/GroupList.php">
+                                        <img src="../image/GroupChat.svg" alt="Group Chat" class="icon-img">
+                                    </a>
+                                </div>
+                                <a href="../GroupChat/GroupList.php"><span class="menu-text">Group Chat</span></a>
+                            <?php } else { ?>
+                                <div class="menu-icon">
+                                    <a href="../Login/LoginIn.php">
                                         <img src="../image/GroupChat.svg" alt="Group Chat" class="icon-img">
                                     </a>
                                 </div>
                                 <a href="../Login/LoginIn.php"><span class="menu-text">Group Chat</span></a>
+                            <?php } ?>
                         </label>
                     </li>
                 </ul>
             </div>
             <div class="main-content">
+                <div class="global-header">
+                    <div>
+                        <p class="eyebrow">グローバルフィード</p>
+                        <h1>全体のつぶやき</h1>
+                        <p class="lead">最新の投稿や添付画像をタイムライン形式で確認できます。</p>
+                    </div>
+                    <div class="action-chip">リアルタイムで更新</div>
+                </div>
                 <div class="global-chat">
                     <?php
                     $user = $pdo->prepare('SELECT g.*, u.* FROM GlobalChat g JOIN Users u ON g.userID = u.userID ORDER BY g.commentID DESC');
                     $user->execute();
                     $questions = $user->fetchAll(PDO::FETCH_ASSOC);
                     $rply = $pdo->prepare('SELECT COUNT(*) as rplyCount FROM GlobalChat WHERE replyID = ?');
+                    if (empty($questions)) { ?>
+                        <p class="empty-state">まだ投稿がありません。最初のメッセージを共有してみましょう。</p>
+                    <?php }
                     foreach ($questions as $row) {
                         if ($row['replyID'] == null) {
                             $rply->execute([$row['commentID']]);
                             $rplya = $rply->fetch(PDO::FETCH_ASSOC);
-                            $rplyCount = $rplya['rplyCount'];?>
+                            $rplyCount = $rplya['rplyCount']; ?>
                             <div class="chat-comment">
                                 <?php if ($row['userID'] != "Anonymous") { ?>
                                 <a href="../Profile/OtherProfile.php?userID=<?= $row['userID'] ?>" class="account">
@@ -140,18 +159,18 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                                 <?php } ?>
                                     <div class="account-image"><?php
                                         if (!empty($row['profileIcon'])) {
-                                            ?><img src="<?=htmlspecialchars($row['profileIcon'])?>" alt="画像が読み込めません"><?php
+                                            ?><img src="<?= htmlspecialchars($row['profileIcon']) ?>" alt="画像が読み込めません"><?php
                                         } else {
                                             ?><img src="../image/DefaultIcon.svg" alt="ProfileImage"><?php
-                                        }?>
+                                        } ?>
                                     </div>
                                     <p class="account-name"><?= htmlspecialchars($row['nickname']) ?> </p>
                                 </a>
                                 <a href="Globalrply.php?commentID=<?= $row['commentID'] ?>" class="linkrply-atag">
                                     <p class="comment"><?= htmlspecialchars($row['commentText']) ?></p><?php
-                                    if($row['appendFile']){?>
+                                    if ($row['appendFile']) { ?>
                                         <img src="<?= $row['appendFile'] ?>" alt="画像を読み込めません"><?php
-                                    }?>
+                                    } ?>
                                 </a>
                                 <div class="rply">
                                     <img src="../image/RplyMark.svg" alt="rply" height="20" width="20">
@@ -175,9 +194,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                         <input type="hidden" name="userID" value=<?= $userID ?>>
                         <input type="text" class="chat-text" placeholder="テキストを入力" name="commentText" spellcheck="false">
                         <div class="image-preview">
-                            <img id="preview-image" src="" >
+                            <img id="preview-image" src="">
                         </div>
-                        <button type="filebutton" onclick="triggerFileInput(event)" class="file-icon">
+                        <button type="button" onclick="triggerFileInput(event)" class="file-icon">
                             <img src="../image/FileIcon.svg" width="20" height="20" alt="ファイル添付">
                         </button>
                         <input type="file" id="file-upload" name="file" style="display: none;" onchange="displayFileName(this)">

--- a/Top/css/toppage.css
+++ b/Top/css/toppage.css
@@ -3,9 +3,16 @@ body {
     margin: 0;
     min-height: 100vh;
     background-color: #2c2c2c;
+    font-family: 'Noto Sans JP', 'Segoe UI', sans-serif;
+    color: #fff;
 }
 
 p {
+    color: #fff;
+}
+
+h1 {
+    margin: 0;
     color: #fff;
 }
 
@@ -81,6 +88,8 @@ a{
     display: flex;
     justify-content: center;
     align-items: center;
+    background: #3b3b3b;
+    box-shadow: 0 6px 14px rgba(0, 0, 0, 0.28);
 }
 
 .search-buttom {
@@ -142,6 +151,7 @@ a{
 }
 
 /* メインコンテンツ */
+
 .main-content {
     margin-left: 70px;
     height: calc(100% - 5px);
@@ -151,13 +161,52 @@ a{
     flex-direction: column; /* 縦方向の配置 */
     align-items: center;
     width: calc(100% - 70px); /* サイドバーの幅を差し引いた幅 */
-    padding-top: 10px;
+    padding: 16px 20px 20px;
+    gap: 14px;
+    box-sizing: border-box;
+}
+
+.global-header {
+    width: 100%;
+    max-width: 1080px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    color: #9ef0c2;
+    letter-spacing: 1px;
+    font-size: 12px;
+    margin: 0 0 6px 0;
+}
+
+.lead {
+    margin: 6px 0 0 0;
+    color: #d5d5d5;
+    line-height: 1.6;
+}
+
+.action-chip {
+    border: 1px solid #06c286;
+    border-radius: 999px;
+    padding: 8px 14px;
+    color: #06c286;
+    font-weight: bold;
+    background: rgba(6, 194, 134, 0.12);
 }
 
 .global-chat {
-    overflow: auto;
+    overflow-y: auto;
     width: 100%;
-    height: 100%;
+    max-width: 1080px;
+    flex: 1;
+    background: #363636;
+    border-radius: 16px;
+    padding: 16px 14px 110px;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
 }
 
 .global-chat::-webkit-scrollbar {
@@ -173,12 +222,13 @@ a{
 }
 
 .chat-comment {
-    width: 80%;
-    margin: 0 auto;
-    padding: 10px 10px 5px 10px;
+    width: 100%;
+    max-width: 1040px;
+    margin: 0 auto 10px auto;
+    padding: 12px 14px 8px 14px;
     background-color: #494949;
-    border-radius: 5px;
-    margin-bottom: 5px;
+    border-radius: 12px;
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
 }
 
 .account{
@@ -220,9 +270,11 @@ a{
 }
 
 .linkrply-atag img {
-    height: 200px;
+    height: 220px;
     object-fit: cover; /* アスペクト比を保ちつつコンテナをカバーする */
     margin: 15px;
+    border-radius: 8px;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
 }
 
 .rply{
@@ -259,29 +311,54 @@ a{
 }
 
 /*-----入力フォーム------*/
+
+.empty-state {
+    color: #d5d5d5;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px dashed #5f5f5f;
+    border-radius: 12px;
+    padding: 18px;
+    margin: 0 6px;
+}
+
 .text-box {
     display: flex;
+    flex-direction: column;
+    gap: 12px;
     align-items: center;
     width:100%; /* サイドバーを除いた幅 */
+    max-width: 1080px;
+    padding: 12px 10px 8px;
+    box-sizing: border-box;
+    position: sticky;
+    bottom: 0;
+    background: linear-gradient(180deg, rgba(44,44,44,0.45) 0%, rgba(44,44,44,0.9) 60%, #2c2c2c 100%);
+    backdrop-filter: blur(3px);
 }
 
 /* 添付画像プレビュー */
 #file-preview-container {
     display: none; /* 初期状態で非表示 */
     align-items: center;
-    border: none;
-    margin-left: 7%;
-    margin-bottom: 47px;
-    display: flex;
+    border: 1px dashed #06c286;
+    margin: 0;
+    padding: 10px 12px;
+    gap: 12px;
+    width: 100%;
+    box-sizing: border-box;
+    border-radius: 12px;
+    background: rgba(6, 194, 134, 0.06);
+    position: relative;
 }
 
 #file-preview {
     display: none;
     padding: 10px 0 10px 0;
     max-width: 500px;
-    height: 25vh;
+    height: 20vh;
     margin-right: 10px;
     object-fit: cover;
+    border-radius: 10px;
 }
 
 #file-name {
@@ -294,8 +371,8 @@ a{
     cursor: pointer; /* ポインターの変更 */
     display: none; /* 初期状態では非表示 */
     position: absolute;
-    bottom: 56px;
-    right: 9%;
+    top: 8px;
+    right: 8px;
 }
 
 .send {
@@ -303,11 +380,12 @@ a{
     border: 3px solid #06c286;
     border-radius: 15px; /* 丸みを帯びた縁を設定 */
     background-color: #2c2c2c;
-    position: absolute; /* 絶対配置 */
-    left: 7%;
-    bottom: 0; /* 下端に配置 */
-    width: 85%;
+    width: 100%;
     align-items: center; /* 上下中央に配置 */
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4);
+    gap: 4px;
+    padding-right: 8px;
+    box-sizing: border-box;
 }
 
 .chat-text {
@@ -317,7 +395,8 @@ a{
     border: none; /* ボーダーを削除 */
     background-color: transparent; /* 背景色を透明に */
     color: #FFFFFF; /* テキストの色を白に */
-    padding-left: 10px; /* テキストのインデント */
+    padding: 0 10px; /* テキストのインデント */
+    font-size: 15px;
 }
 
 .send-button, .file-icon {

--- a/Top/js/appendImage.js
+++ b/Top/js/appendImage.js
@@ -1,4 +1,4 @@
-function triggerFileInput() {
+function triggerFileInput(event) {
     event.preventDefault();
     document.getElementById('file-upload').click();
 }


### PR DESCRIPTION
## Summary
- refresh the top page layout with improved typography, sticky composer, and clearer navigation including the group chat entry
- add full group chat experience with group list/creation, membership actions, and dedicated chat room with auto-updating history
- document supporting database tables for groups, members, and messages

## Testing
- php -l Top/TopPage.php
- php -l GroupChat/GroupList.php
- php -l GroupChat/GroupRoom.php
- php -l GroupChat/GroupHistory.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69214c8b8dd083239bc386f6bef5ff48)